### PR TITLE
support floats in mssql

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -36,6 +36,9 @@ class Query extends AbstractQuery {
         paramType.type = TYPES.Int;
       } else {
         paramType.type = TYPES.Numeric;
+        if (value % 1 !== 0) {
+          paramType.type = TYPES.Float;
+        }
         //Default to a reasonable numeric precision/scale pending more sophisticated logic
         paramType.typeOptions = { precision: 30, scale: 15 };
       }


### PR DESCRIPTION
When trying to insert numbers with decimals it the number gets parsed and 22.22 ends up being 2222000000000000000 which is out of range. this detects if the parameter has decimals and sets it to be treated like a float, i dont know if this is perfect but it is definitely better than what was there which was unusable for decimals

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
